### PR TITLE
Fix `omisvm()` to allow data with 2 levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mildsvm
 Type: Package
 Title: Multiple-instance Learning in R
-Version: 0.3.1.9012
+Version: 0.3.1.9013
 Authors@R: 
     c(person("Sean", "Kent",
              email = "skent259@gmail.com",

--- a/R/utils-datarep.R
+++ b/R/utils-datarep.R
@@ -16,7 +16,9 @@
 .e <- function(q, len) {
   x <- rep(0, len)
   x[q] <- 1
-  names(x) <- paste0("dr", seq_len(len))
+  if (length(x) > 0) {
+    names(x) <- paste0("dr", seq_len(len))
+  }
   return(x)
 }
 

--- a/tests/testthat/test_omisvm.R
+++ b/tests/testthat/test_omisvm.R
@@ -335,3 +335,15 @@ test_that("`omisvm()` can use all values of `s`", {
     expect_warning()
 })
 
+test_that("`omisvm()` works when passing label with 2 levels", {
+
+  ind <- df1$bag_label %in% c(2, 5)
+  expect_warning({mdl1 <- omisvm(df1[ind, ])},
+                   "Only 2 levels detected") %>%
+    suppressWarnings() %>%
+    suppressMessages()
+
+  preds <- predict(mdl1, new_data = df1)$.pred_class
+  expect_equal(length(table(preds)), 2)
+})
+


### PR DESCRIPTION
* error occuring with `.e()` being length 0 when trying to name it
* add test to check for this in future
* increment version number to 0.3.1.9012